### PR TITLE
perf: move path.slice inside iterateFirst

### DIFF
--- a/src/ei.ts
+++ b/src/ei.ts
@@ -343,7 +343,7 @@ export class Raikiri<T> {
                 params: {}
             }
 
-        return iterateFirst(path.slice(1), node, {})
+        return iterateFirst(path, node, {})
     }
 
     private _m(method: string, path: string) {
@@ -364,6 +364,7 @@ const iterateFirst = <T>(
           params: Record<string, string>
       }
     | undefined => {
+    path = path.slice(1)
     const child = node.children.get(path.charCodeAt(node.part?.length))
 
     if (node.part && path.slice(0, node.part.length) !== node.part) return


### PR DESCRIPTION
# Summary
Move the `path.slice(1)` operation from the invocation of `iterateFirst` to the beginning of the function body. This makes the `short static` and `static with same radix` performance basically identical (whereas short static was a bit slower before). 

## Details
- All tests seem to still be passing ✅ 
- I have no idea why this improves performance; my only speculation is something with code-inlining 🤓 

## Benchmarks
Before: 
```
===================
 Raikiri benchmark
===================
short static: 76,950,454 ops/sec
static with same radix: 92,844,761 ops/sec
dynamic route: 5,652,313 ops/sec
mixed static dynamic: 7,389,597 ops/sec
long static: 74,840,261 ops/sec
wildcard: 10,135,139 ops/sec
```

After:
```
===================
 Raikiri benchmark
===================
short static: 92,581,877 ops/sec
static with same radix: 94,573,451 ops/sec
dynamic route: 5,638,227 ops/sec
mixed static dynamic: 7,275,276 ops/sec
long static: 77,918,030 ops/sec
wildcard: 10,085,021 ops/sec
```